### PR TITLE
Align quest completion with Supabase schema

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,7 @@ async function getOrInitUserStats(userId) {
 
   const { data: inserted, error: upsertError } = await supabase
     .from('user_stats')
-    .upsert({ user_id: userId, xp: 0, coins: 0, level: 1 }, { onConflict: 'user_id' })
+    .upsert({ user_id: userId, xp: 0, coins: 0 }, { onConflict: 'user_id' })
     .select('*')
     .single();
 
@@ -112,8 +112,7 @@ async function initApp() {
       const userStats = await getOrInitUserStats(user.id);
       statsModule.updateUserStats({
         xp: userStats.xp ?? 0,
-        coins: userStats.coins ?? 0,
-        level: userStats.level ?? 1
+        coins: userStats.coins ?? 0
       });
 
       ui.updateStatsDisplay();
@@ -170,8 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const userStats = await getOrInitUserStats(result.user.id);
         statsModule.updateUserStats({
           xp: userStats.xp ?? 0,
-          coins: userStats.coins ?? 0,
-          level: userStats.level ?? 1
+          coins: userStats.coins ?? 0
         });
 
         await quests.fetchQuests(result.user.id);

--- a/src/modules/quests/quests.js
+++ b/src/modules/quests/quests.js
@@ -73,7 +73,7 @@ function initQuests(supabase, stats) {
         try {
             const { data, error } = await supabase
                 .from('quests')
-                .update({ completed: true, completed_at: new Date().toISOString() })
+                .update({ completed: true })
                 .eq('id', questId)
                 .select();
             
@@ -81,7 +81,7 @@ function initQuests(supabase, stats) {
             
             if (data && data.length > 0) {
                 // Update local quests array
-                quests = quests.map(q => q.id === questId ? { ...q, completed: true, completed_at: new Date().toISOString() } : q);
+                quests = quests.map(q => q.id === questId ? { ...q, completed: true } : q);
                 
                 // Award XP and coins based on quest type
                 const quest = data[0];
@@ -114,10 +114,9 @@ function initQuests(supabase, stats) {
                 const userStats = stats.getUserStats();
                 const { error: statsError } = await supabase
                     .from('user_stats')
-                    .update({ 
-                        xp: userStats.xp, 
-                        coins: userStats.coins, 
-                        level: userStats.level 
+                    .update({
+                        xp: userStats.xp,
+                        coins: userStats.coins
                     })
                     .eq('user_id', quest.user_id);
                 

--- a/src/modules/ui/ui.js
+++ b/src/modules/ui/ui.js
@@ -7,6 +7,10 @@
  * @returns {Object} - Exposed UI helper functions
  */
 function initUI(elements, stats) {
+    // Keep track of the latest callbacks passed into initEventListeners so
+    // other helpers (like updateUserInfo) can safely reference them.
+    let registeredCallbacks = {};
+
     /* ------------------------------------------------------------------
      * Generic helpers
      * ---------------------------------------------------------------- */
@@ -91,22 +95,6 @@ function initUI(elements, stats) {
         } else {
             elements.userInfo.classList.add('hidden');
         }
-
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -135,21 +123,6 @@ function initUI(elements, stats) {
             });
         }
 
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -212,6 +185,8 @@ function initUI(elements, stats) {
      * Event-listener initialisation hooks
      * ---------------------------------------------------------------- */
     function initEventListeners(callbacks = {}) {
+        registeredCallbacks = callbacks;
+
         // Show modal
         elements.createQuestBtn?.addEventListener('click', () => toggleQuestFormModal(true));
         // Close modal
@@ -220,12 +195,12 @@ function initUI(elements, stats) {
         elements.clearQuestBtn?.addEventListener('click', () => clearQuestForm());
 
         // Additional external callbacks (complete, delete, filter etc.) can be wired through here
-        if (callbacks.onFilterChange) {
+        if (registeredCallbacks.onFilterChange) {
             elements.typeFilter?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
+                registeredCallbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
             });
             elements.showCompleted?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
+                registeredCallbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
             });
         }
 
@@ -238,9 +213,9 @@ function initUI(elements, stats) {
                 if (!card) return;
                 const id = card.dataset.id;
                 if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
+                    registeredCallbacks.onCompleteQuest && registeredCallbacks.onCompleteQuest(id);
                 } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
+                    registeredCallbacks.onDeleteQuest && registeredCallbacks.onDeleteQuest(id);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- stop writing to nonexistent `completed_at` and `level` columns so quest completion succeeds with the deployed Supabase schema
- keep local quest state in sync after completion and continue awarding rewards without relying on removed columns
- ensure UI quest filter callbacks always reference the latest registered handlers

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d586237ed8832f91dc16a647dc24e5