### PR TITLE
Align quest completion with Supabase schema

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,7 @@ async function getOrInitUserStats(userId) {
 
   const { data: inserted, error: upsertError } = await supabase
     .from('user_stats')
-    .upsert({ user_id: userId, xp: 0, coins: 0, level: 1 }, { onConflict: 'user_id' })
+    .upsert({ user_id: userId, xp: 0, coins: 0 }, { onConflict: 'user_id' })
     .select('*')
     .single();
 
@@ -112,8 +112,7 @@ async function initApp() {
       const userStats = await getOrInitUserStats(user.id);
       statsModule.updateUserStats({
         xp: userStats.xp ?? 0,
-        coins: userStats.coins ?? 0,
-        level: userStats.level ?? 1
+        coins: userStats.coins ?? 0
       });
 
       ui.updateStatsDisplay();
@@ -170,8 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const userStats = await getOrInitUserStats(result.user.id);
         statsModule.updateUserStats({
           xp: userStats.xp ?? 0,
-          coins: userStats.coins ?? 0,
-          level: userStats.level ?? 1
+          coins: userStats.coins ?? 0
         });
 
         await quests.fetchQuests(result.user.id);

--- a/src/modules/quests/quests.js
+++ b/src/modules/quests/quests.js
@@ -71,68 +71,69 @@ function initQuests(supabase, stats) {
     // Complete a quest
     async function completeQuest(questId) {
         try {
-            const { data, error } = await supabase
-                .from('quests')
-                .update({ completed: true, completed_at: new Date().toISOString() })
-                .eq('id', questId)
-                .select();
-            
-            if (error) throw error;
-            
-            if (data && data.length > 0) {
-                // Update local quests array
-                quests = quests.map(q => q.id === questId ? { ...q, completed: true, completed_at: new Date().toISOString() } : q);
-                
-                // Award XP and coins based on quest type
-                const quest = data[0];
-                let xpReward = 0;
-                let coinReward = 0;
-                
-                switch (quest.type) {
-                    case 'daily':
-                        xpReward = 10;
-                        coinReward = 1;
-                        break;
-                    case 'weekly':
-                        xpReward = 50;
-                        coinReward = 5;
-                        break;
-                    case 'one_time':
-                        xpReward = 25;
-                        coinReward = 3;
-                        break;
-                    default:
-                        xpReward = 5;
-                        coinReward = 1;
-                }
-                
-                // Update user stats
-                stats.addXp(xpReward);
-                stats.addCoins(coinReward);
-                
-                // Update user_stats in database
-                const userStats = stats.getUserStats();
-                const { error: statsError } = await supabase
-                    .from('user_stats')
-                    .update({ 
-                        xp: userStats.xp, 
-                        coins: userStats.coins, 
-                        level: userStats.level 
-                    })
-                    .eq('user_id', quest.user_id);
-                
-                if (statsError) {
-                    console.error('Error updating stats:', statsError);
-                }
-                
-                return { 
-                    success: true, 
-                    quest: data[0],
-                    rewards: { xp: xpReward, coins: coinReward }
-                };
+            const quest = quests.find(q => q.id === questId);
+
+            if (!quest) {
+                return { success: false, error: 'Quest not found' };
             }
-            
-            return { success: false, error: 'No data returned' };
+
+            if (quest.completed) {
+                return { success: true, quest, rewards: { xp: 0, coins: 0 } };
+            }
+
+            const { error } = await supabase
+                .from('quests')
+                .update({ completed: true }, { returning: 'minimal' })
+                .eq('id', questId);
+
+            if (error) throw error;
+
+            const normalizedType = (quest.type || '').toLowerCase();
+            let xpReward = 0;
+            let coinReward = 0;
+
+            switch (normalizedType) {
+                case 'daily':
+                    xpReward = 10;
+                    coinReward = 1;
+                    break;
+                case 'weekly':
+                    xpReward = 50;
+                    coinReward = 5;
+                    break;
+                case 'one_time':
+                    xpReward = 25;
+                    coinReward = 3;
+                    break;
+                default:
+                    xpReward = 5;
+                    coinReward = 1;
+            }
+
+            const updatedQuest = { ...quest, completed: true };
+            quests = quests.map(q => (q.id === questId ? updatedQuest : q));
+
+            stats.addXp(xpReward);
+            stats.addCoins(coinReward);
+
+            const userStats = stats.getUserStats();
+            const { error: statsError } = await supabase
+                .from('user_stats')
+                .update({
+                    xp: userStats.xp,
+                    coins: userStats.coins
+                })
+                .eq('user_id', quest.user_id);
+
+            if (statsError) {
+                console.error('Error updating stats:', statsError);
+            }
+
+            return {
+                success: true,
+                quest: updatedQuest,
+                rewards: { xp: xpReward, coins: coinReward }
+            };
         } catch (error) {
             console.error('Error completing quest:', error);
             return { success: false, error: error.message };

--- a/src/modules/ui/ui.js
+++ b/src/modules/ui/ui.js
@@ -91,22 +91,6 @@ function initUI(elements, stats) {
         } else {
             elements.userInfo.classList.add('hidden');
         }
-
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -135,21 +119,6 @@ function initUI(elements, stats) {
             });
         }
 
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -212,6 +181,8 @@ function initUI(elements, stats) {
      * Event-listener initialisation hooks
      * ---------------------------------------------------------------- */
     function initEventListeners(callbacks = {}) {
+        const { onFilterChange, onCompleteQuest, onDeleteQuest } = callbacks;
+
         // Show modal
         elements.createQuestBtn?.addEventListener('click', () => toggleQuestFormModal(true));
         // Close modal
@@ -220,12 +191,12 @@ function initUI(elements, stats) {
         elements.clearQuestBtn?.addEventListener('click', () => clearQuestForm());
 
         // Additional external callbacks (complete, delete, filter etc.) can be wired through here
-        if (callbacks.onFilterChange) {
+        if (onFilterChange) {
             elements.typeFilter?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
+                onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
             });
             elements.showCompleted?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
+                onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
             });
         }
 
@@ -238,9 +209,9 @@ function initUI(elements, stats) {
                 if (!card) return;
                 const id = card.dataset.id;
                 if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
+                    onCompleteQuest && onCompleteQuest(id);
                 } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
+                    onDeleteQuest && onDeleteQuest(id);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- stop writing to nonexistent `completed_at` and `level` columns so quest completion succeeds with the deployed Supabase schema
- keep local quest state in sync after completion, awarding rewards from cached quest data without relying on missing Supabase columns
- ensure UI quest filter callbacks always reference the latest registered handlers by destructuring them when wiring listeners

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68d586237ed8832f91dc16a647dc24e5