### PR TITLE
Fix quest completion handlers and Supabase updates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,7 @@ async function getOrInitUserStats(userId) {
 
   const { data: inserted, error: upsertError } = await supabase
     .from('user_stats')
-    .upsert({ user_id: userId, xp: 0, coins: 0, level: 1 }, { onConflict: 'user_id' })
+    .upsert({ user_id: userId, xp: 0, coins: 0 }, { onConflict: 'user_id' })
     .select('*')
     .single();
 
@@ -112,8 +112,7 @@ async function initApp() {
       const userStats = await getOrInitUserStats(user.id);
       statsModule.updateUserStats({
         xp: userStats.xp ?? 0,
-        coins: userStats.coins ?? 0,
-        level: userStats.level ?? 1
+        coins: userStats.coins ?? 0
       });
 
       ui.updateStatsDisplay();
@@ -170,8 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const userStats = await getOrInitUserStats(result.user.id);
         statsModule.updateUserStats({
           xp: userStats.xp ?? 0,
-          coins: userStats.coins ?? 0,
-          level: userStats.level ?? 1
+          coins: userStats.coins ?? 0
         });
 
         await quests.fetchQuests(result.user.id);

--- a/src/modules/quests/quests.js
+++ b/src/modules/quests/quests.js
@@ -3,6 +3,8 @@
 // Global state
 let quests = [];
 
+const QUEST_COLUMNS = 'id,user_id,title,description,type,due_date,completed,created_at';
+
 /**
  * Initialize quests module
  * @param {Object} supabase - Supabase client instance
@@ -15,7 +17,7 @@ function initQuests(supabase, stats) {
         try {
             const { data, error } = await supabase
                 .from('quests')
-                .select('*')
+                .select(QUEST_COLUMNS)
                 .eq('user_id', userId)
                 .order('created_at', { ascending: false });
             
@@ -48,11 +50,11 @@ function initQuests(supabase, stats) {
                 completed: false,
                 created_at: new Date().toISOString()
             };
-            
+
             const { data, error } = await supabase
                 .from('quests')
                 .insert([newQuest])
-                .select();
+                .select(QUEST_COLUMNS);
             
             if (error) throw error;
             
@@ -71,68 +73,71 @@ function initQuests(supabase, stats) {
     // Complete a quest
     async function completeQuest(questId) {
         try {
+            const quest = quests.find(q => q.id === questId);
+
+            if (!quest) {
+                return { success: false, error: 'Quest not found' };
+            }
+
+            if (quest.completed) {
+                return { success: true, quest, rewards: { xp: 0, coins: 0 } };
+            }
+
             const { data, error } = await supabase
                 .from('quests')
-                .update({ completed: true, completed_at: new Date().toISOString() })
+                .update({ completed: true })
                 .eq('id', questId)
-                .select();
-            
+                .select(QUEST_COLUMNS)
+                .maybeSingle();
+
             if (error) throw error;
-            
-            if (data && data.length > 0) {
-                // Update local quests array
-                quests = quests.map(q => q.id === questId ? { ...q, completed: true, completed_at: new Date().toISOString() } : q);
-                
-                // Award XP and coins based on quest type
-                const quest = data[0];
-                let xpReward = 0;
-                let coinReward = 0;
-                
-                switch (quest.type) {
-                    case 'daily':
-                        xpReward = 10;
-                        coinReward = 1;
-                        break;
-                    case 'weekly':
-                        xpReward = 50;
-                        coinReward = 5;
-                        break;
-                    case 'one_time':
-                        xpReward = 25;
-                        coinReward = 3;
-                        break;
-                    default:
-                        xpReward = 5;
-                        coinReward = 1;
-                }
-                
-                // Update user stats
-                stats.addXp(xpReward);
-                stats.addCoins(coinReward);
-                
-                // Update user_stats in database
-                const userStats = stats.getUserStats();
-                const { error: statsError } = await supabase
-                    .from('user_stats')
-                    .update({ 
-                        xp: userStats.xp, 
-                        coins: userStats.coins, 
-                        level: userStats.level 
-                    })
-                    .eq('user_id', quest.user_id);
-                
-                if (statsError) {
-                    console.error('Error updating stats:', statsError);
-                }
-                
-                return { 
-                    success: true, 
-                    quest: data[0],
-                    rewards: { xp: xpReward, coins: coinReward }
-                };
+
+            const normalizedType = (quest.type || '').toLowerCase();
+            let xpReward = 0;
+            let coinReward = 0;
+
+            switch (normalizedType) {
+                case 'daily':
+                    xpReward = 10;
+                    coinReward = 1;
+                    break;
+                case 'weekly':
+                    xpReward = 50;
+                    coinReward = 5;
+                    break;
+                case 'one_time':
+                    xpReward = 25;
+                    coinReward = 3;
+                    break;
+                default:
+                    xpReward = 5;
+                    coinReward = 1;
             }
-            
-            return { success: false, error: 'No data returned' };
+
+            const updatedQuest = data ? data : { ...quest, completed: true };
+            quests = quests.map(q => (q.id === questId ? updatedQuest : q));
+
+            stats.addXp(xpReward);
+            stats.addCoins(coinReward);
+
+            const userStats = stats.getUserStats();
+            const { error: statsError } = await supabase
+                .from('user_stats')
+                .update({
+                    xp: userStats.xp,
+                    coins: userStats.coins
+                })
+                .eq('user_id', quest.user_id);
+
+            if (statsError) {
+                console.error('Error updating stats:', statsError);
+            }
+
+            return {
+                success: true,
+                quest: updatedQuest,
+                rewards: { xp: xpReward, coins: coinReward }
+            };
         } catch (error) {
             console.error('Error completing quest:', error);
             return { success: false, error: error.message };
@@ -166,8 +171,11 @@ function initQuests(supabase, stats) {
 
     // Filter quests by type and completion status
     function filterQuests(type = 'All', showCompleted = false) {
+        const normalizedType = typeof type === 'string' ? type.toLowerCase() : 'all';
+
         return quests.filter(quest => {
-            const typeMatch = type === 'All' || quest.type === type;
+            const questType = (quest.type || '').toLowerCase();
+            const typeMatch = normalizedType === 'all' || questType === normalizedType;
             const completionMatch = showCompleted || !quest.completed;
             return typeMatch && completionMatch;
         });

--- a/src/modules/quests/quests.js
+++ b/src/modules/quests/quests.js
@@ -92,7 +92,8 @@ function initQuests(supabase, stats) {
 
             if (error) throw error;
 
-            const normalizedType = (quest.type || '').toLowerCase();
+            const persistedQuest = data ? { ...quest, ...data } : { ...quest, completed: true };
+            const normalizedType = (persistedQuest.type || quest.type || '').toLowerCase();
             let xpReward = 0;
             let coinReward = 0;
 
@@ -114,7 +115,7 @@ function initQuests(supabase, stats) {
                     coinReward = 1;
             }
 
-            const updatedQuest = data ? data : { ...quest, completed: true };
+            const updatedQuest = { ...persistedQuest, completed: true };
             quests = quests.map(q => (q.id === questId ? updatedQuest : q));
 
             stats.addXp(xpReward);
@@ -127,7 +128,7 @@ function initQuests(supabase, stats) {
                     xp: userStats.xp,
                     coins: userStats.coins
                 })
-                .eq('user_id', quest.user_id);
+                .eq('user_id', updatedQuest.user_id || quest.user_id);
 
             if (statsError) {
                 console.error('Error updating stats:', statsError);

--- a/src/modules/ui/ui.js
+++ b/src/modules/ui/ui.js
@@ -182,7 +182,6 @@ function initUI(elements, stats) {
         });
     }
     /* ------------------------------------------------------------------
-     * Event-listener/* ------------------------------------------------------------------
      * Event-listener initialisation hooks
      * ---------------------------------------------------------------- */
     const listenerState = {
@@ -251,7 +250,7 @@ function initUI(elements, stats) {
 
         // If filters were already set before this call, immediately propagate the
         // latest values to keep the UI and quest list in sync with the newly
-        // registered callbacks.
+        // assigned listenerState callbacks.
         triggerFilterChange();
     }
 

--- a/src/modules/ui/ui.js
+++ b/src/modules/ui/ui.js
@@ -91,22 +91,6 @@ function initUI(elements, stats) {
         } else {
             elements.userInfo.classList.add('hidden');
         }
-
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -115,7 +99,12 @@ function initUI(elements, stats) {
     function clearQuestForm() {
         elements.questTitle.value = '';
         elements.questDescription.value = '';
-        elements.questType.value = 'Daily';
+        // Ensure the select value matches the option values defined in the
+        // HTML (lowercase with underscores) so clearing the form restores the
+        // default Daily option instead of leaving the select empty.
+        if (elements.questType) {
+            elements.questType.value = 'daily';
+        }
         elements.questDueDate.value = '';
     }
 
@@ -135,21 +124,6 @@ function initUI(elements, stats) {
             });
         }
 
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
-                }
-            });
-        }
     }
 
     /* ------------------------------------------------------------------
@@ -211,7 +185,32 @@ function initUI(elements, stats) {
      * Event-listener/* ------------------------------------------------------------------
      * Event-listener initialisation hooks
      * ---------------------------------------------------------------- */
+    const listenerState = {
+        onFilterChange: null,
+        onCompleteQuest: null,
+        onDeleteQuest: null
+    };
+
+    let filterListenersBound = false;
+    let questActionsListenerBound = false;
+
+    function getFilterValues() {
+        const type = elements.typeFilter?.value || 'all';
+        const showCompleted = !!elements.showCompleted?.checked;
+        return { type, showCompleted };
+    }
+
+    function triggerFilterChange() {
+        if (typeof listenerState.onFilterChange !== 'function') return;
+        const { type, showCompleted } = getFilterValues();
+        listenerState.onFilterChange(type, showCompleted);
+    }
+
     function initEventListeners(callbacks = {}) {
+        listenerState.onFilterChange = callbacks.onFilterChange || null;
+        listenerState.onCompleteQuest = callbacks.onCompleteQuest || null;
+        listenerState.onDeleteQuest = callbacks.onDeleteQuest || null;
+
         // Show modal
         elements.createQuestBtn?.addEventListener('click', () => toggleQuestFormModal(true));
         // Close modal
@@ -219,31 +218,41 @@ function initUI(elements, stats) {
         // Clear quest form
         elements.clearQuestBtn?.addEventListener('click', () => clearQuestForm());
 
-        // Additional external callbacks (complete, delete, filter etc.) can be wired through here
-        if (callbacks.onFilterChange) {
-            elements.typeFilter?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
-            });
-            elements.showCompleted?.addEventListener('change', () => {
-                callbacks.onFilterChange(elements.typeFilter.value, elements.showCompleted.checked);
-            });
+        if (!filterListenersBound) {
+            filterListenersBound = true;
+            const handleFilterChange = () => triggerFilterChange();
+            elements.typeFilter?.addEventListener('change', handleFilterChange);
+            elements.showCompleted?.addEventListener('change', handleFilterChange);
         }
 
-        // Delegated quest actions
-        if (elements.questsContainer) {
-            elements.questsContainer.addEventListener('click', (e) => {
-                const target = e.target.closest('button');
-                if (!target) return;
-                const card = e.target.closest('.quest-item');
-                if (!card) return;
-                const id = card.dataset.id;
-                if (target.classList.contains('complete-btn')) {
-                    callbacks.onCompleteQuest && callbacks.onCompleteQuest(id);
-                } else if (target.classList.contains('delete-btn')) {
-                    callbacks.onDeleteQuest && callbacks.onDeleteQuest(id);
+        if (!questActionsListenerBound && elements.questsContainer) {
+            questActionsListenerBound = true;
+            elements.questsContainer.addEventListener('click', (event) => {
+                const button = event.target.closest('button');
+                if (!button) return;
+
+                const questCard = button.closest('.quest-item');
+                if (!questCard) return;
+
+                const questId = questCard.dataset.id;
+                if (!questId) return;
+
+                if (button.classList.contains('complete-btn')) {
+                    if (typeof listenerState.onCompleteQuest === 'function') {
+                        listenerState.onCompleteQuest(questId);
+                    }
+                } else if (button.classList.contains('delete-btn')) {
+                    if (typeof listenerState.onDeleteQuest === 'function') {
+                        listenerState.onDeleteQuest(questId);
+                    }
                 }
             });
         }
+
+        // If filters were already set before this call, immediately propagate the
+        // latest values to keep the UI and quest list in sync with the newly
+        // registered callbacks.
+        triggerFilterChange();
     }
 
     /* ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure UI quest callbacks are stored safely, bind delegated handlers once, and immediately propagate filter changes to avoid ReferenceErrors during quest actions
- reset the quest form to the correct Daily option when clearing inputs so newly created quests keep valid types
- limit quest queries to known columns and fetch the updated row when marking quests complete so Supabase updates succeed and local state stays in sync

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d586237ed8832f91dc16a647dc24e5