### PR TITLE
Handle missing quest data on completion

### DIFF
--- a/src/modules/quests/quests.js
+++ b/src/modules/quests/quests.js
@@ -91,7 +91,11 @@ function initQuests(supabase, stats) {
 
             if (error) throw error;
 
-            const persistedQuest = data ? { ...quest, ...data } : { ...quest, completed: true };
+            if (!data) {
+                return { success: false, error: 'Quest completion failed' };
+            }
+
+            const persistedQuest = { ...quest, ...data };
             const normalizedType = (persistedQuest.type || quest.type || '').toLowerCase();
             let xpReward = 0;
             let coinReward = 0;


### PR DESCRIPTION
## Summary
- prevent awarding rewards when quest completion returns no row
- return a failure response if the quest update yields no data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59ab4816c832f9ec8bf1a2ab65346